### PR TITLE
Updated 1.6 version notes to reflect new 1.6.16

### DIFF
--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -28,7 +28,7 @@ owner: Metrix
 
 No new known issues for JMX Bridge 1.7.X. For old known issues, see [below](#1-6).
 
-##<a id='1-6'></a>Version 1.6.15 
+##<a id='1-6'></a>Version 1.6.16 
 
 ### Major Features
 * The addition of CF loggregator data via the firehose is still available, but disabled by default.
@@ -47,7 +47,7 @@ No new known issues for JMX Bridge 1.7.X. For old known issues, see [below](#1-6
 * Upgrading from Ops Metrics 1.4.X to 1.6.X will leave the firehose nozzle job disabled (since it did not exist previously).
 * Upgrading from Ops Metrics 1.5.X to 1.6.X will enable the firehose nozzle by default (since it was enabled before upgrading).
   * If you are upgrading to resolve an installation error with 1.5.X, immediately disable the firehose job before deploying, and enable once you have deployed Elastic Runtime.
-* Stemcell for 1.6.15 is 3232.12
+* Stemcell for 1.6.16 is 3232.17
 
 
 ### Known issues


### PR DESCRIPTION
CVE required bump of Ops Metrics from 1.6.15 to 1.6.16. Updated version number and also updated stemcell reference to correct stemcell for 1.6.16
