### PR TITLE
Update deploy-metrics.html.md.erb

### DIFF
--- a/deploy-metrics.html.md.erb
+++ b/deploy-metrics.html.md.erb
@@ -15,8 +15,6 @@ The JMX Bridge tool is a JMX extension for Elastic Runtime. Follow the instructi
 
 1. Import JMX Bridge into Ops Manager by following the instructions for [Adding and Importing Products](https://docs.pivotal.io/pivotalcf/1-7/customizing/add-delete.html#add-import).
 
-    <p class='note'><strong>Note</strong>: To upgrade from JMX Bridge from 1.6.x to 1.7.x, you must have Ops Manager version 1.7.8 or later.</p>
-
 1. On the Installation Dashboard, click the **JMX Bridge** tile.
 
     <%= image_tag("images/metrics-tile.png") %>


### PR DESCRIPTION
Now that JMX docs are version separated, remove upgrade note highlight on 2 of Step 1 of http://docs.pivotal.io/jmx-bridge/1-8/deploy-metrics.html; as it was 1.7 specific content
