### PR TITLE
Update troubleshooting-uninstall-metrics.html.md.erb

### DIFF
--- a/troubleshooting-uninstall-metrics.html.md.erb
+++ b/troubleshooting-uninstall-metrics.html.md.erb
@@ -16,15 +16,6 @@ The JMX Bridge tool is composed of three virtual machines:
 
 To deploy JMX Bridge, see the [Deploying JMX Bridge](./deploy-metrics.html) topic.
 
-## <a id='upgrade'></a>Resolve Upgrade Error for 1.4 to 1.6 ##
-
-If you see the following error during an upgrade from Ops Metrics 1.4 to 1.6 (now JMX Bridge):
-
-   ![Product Pivotal Ops Metrics could not be upgraded from 1.4 to 1.6. Please contact your Pivotal representative](images/ops-metrics-upgrade-error.png)
-
-1. [Uninstall Ops Metrics 1.4](./troubleshooting-uninstall-metrics.html#uninstall)
-1. [Install Ops Metrics 1.6](http://docs.pivotal.io/pivotalcf/1-6/customizing/deploy-metrics.html#import)
-
 ## <a id='upgrade'></a>Resolve Upgrade Error for 1.6 to 1.7 ##
 If you see the following error during an upgrade from Ops Metrics 1.6 to JMX Bridge 1.7.x:
 


### PR DESCRIPTION
Now that JMX docs are version separated, remove 1.4 to 1.6 troubleshooting note on http://docs.pivotal.io/jmx-bridge/1-8/troubleshooting-uninstall-metrics.html; it is way too far out of date for 1.8 docs
