### PR TITLE
update configure security logging anchor link [#129163459]

### DIFF
--- a/deploy-metrics.html.md.erb
+++ b/deploy-metrics.html.md.erb
@@ -74,7 +74,7 @@ credentials.
 
 1. Once you have provided an SSL certificate and private key, click **Save**.
 
-## <a id='config-ssl'></a>(Optional) Step 5: Disable/Enable Security Logging ##
+## <a id='config-security-logging'></a>(Optional) Step 5: Disable/Enable Security Logging ##
 
 1. Select the **Enable Security Logging** checkbox.
 Access to the JMX endpoint is logged to STDOUT by default. 


### PR DESCRIPTION
Fixed a minor bug from our previous update where the anchor link for Security Logging was the same as Configure SSL.
