### PR TITLE
Update rn-ki.html.md.erb

### DIFF
--- a/rn-ki.html.md.erb
+++ b/rn-ki.html.md.erb
@@ -3,7 +3,7 @@ title: JMX Bridge Release Notes and Known Issues
 owner: Metrix
 ---
 
-<p class="note"><strong>Note</strong>: Before version 1.7.X, JMX Bridge was known as Ops Metrics. For Ops Metrics release notes and known issues, see <a href="#1-6">Version 1.6.15</a>. </p>
+<p class="note"><strong>Note</strong>: Before version 1.7.X, JMX Bridge was known as Ops Metrics. For Ops Metrics release notes and known issues, see [Version 1.6.X](https://docs.pivotal.io/pivotalcf/1-6/pcf-release-notes/p1-v1.6/opsmetrics_rn_1_6.html). </p>
 
 ### Release Notes
 


### PR DESCRIPTION
Notes link in note at top of page was broken on this page. This fixes with correct link to old 1.6 version in note call-out
