### PR TITLE
add deprecation warning to JMX Bridge docs

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -3,6 +3,18 @@ breadcrumb: PCF JMX Bridge
 title: Pivotal Cloud Foundry JMX Bridge
 owner: PCF Metrics
 ---
+<style>
+    .note.warning {
+        background-color: #fdd;
+        border-color: #fbb
+    }
+    .note.warning:before {
+        color: #f99;
+     }
+</style>
+
+<p class="note warning"><strong>IMPORTANT:</strong> The Pivotal Cloud Foundry (PCF) JMX Bridge tile is deprecated, and no further development will be made against this product.</p>
+
 
 The Pivotal Cloud Foundry (PCF) JMX Bridge collects and exposes system data from Cloud Foundry components via a JMX endpoint.
 You can use this system data to monitor your installation and assist in troubleshooting.


### PR DESCRIPTION
JMX Bridge is no longer available and not under development as of 2018-08-31